### PR TITLE
coerces variable to string for os.environ

### DIFF
--- a/story/data.py
+++ b/story/data.py
@@ -12,7 +12,7 @@ _ = lambda msg: gettext.dgettext(domain, msg)
 
 
 def set_language(language):
-    os.environ['LANG'] = language
+    os.environ['LANG'] = str(language)
 
 
 class DataManager(object):


### PR DESCRIPTION
When setting `os.variable`, language needs to be explicitly coerced to string or may cause a type exception. I'm using Python 3.5.1, so this may be a new behavior.